### PR TITLE
fix: :ambulance: Use translated message as data.

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -198,7 +198,8 @@
           "text": "Send",
           "loadingText": "Sending..."
         }
-      }
+      },
+      "success": "Message sent successfully."
     }
   }
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -198,7 +198,8 @@
           "text": "Envoyer",
           "loadingText": "Envoi en cours..."
         }
-      }
+      },
+      "success": "Message envoyé avec succès."
     }
   }
 }

--- a/server/api/messages/index.post.ts
+++ b/server/api/messages/index.post.ts
@@ -23,7 +23,8 @@ const __handler__: ToEventHandler<StoreMessageRequest> = async (event) => {
     });
 
     return {
-      message: JSON.stringify(body),
+      // @ts-expect-error Type instantiation is excessively deep and possibly infinite
+      message: translator.t("messages.store.success"),
     };
   } catch (error) {
     throw Exception.fromUnknown({


### PR DESCRIPTION
Use translated message as data.